### PR TITLE
changing api key for heroku

### DIFF
--- a/app/models/gate.rb
+++ b/app/models/gate.rb
@@ -2,7 +2,7 @@ class Gate < ActiveRecord::Base
   acts_as_readable on: :created_at
 
   def make_shortenURL(long_url)
-    uri = URI.parse("https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyCPjcArjKfGKsxMfa9DPXME7peALnwpLY0")
+    uri = URI.parse("https://www.googleapis.com/urlshortener/v1/url?key=AIzaSyA5-F8Di51O7rijYgzTeT8cmK1w4QDjCT8")
 
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true


### PR DESCRIPTION
#49

http://donut-ari.herokuapp.com/
로 헤로쿠를 열었고, 이에 따라 google api를 call 할 때 사용하는 API key를 다시 발급받았습니다.
(API key 발급시 Referes 를 입력해야 하더라고...)
