### PR TITLE
Feature/issue #233(send sms)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem 'slack-notify', '~> 0.3.2'
 # Use debugger
 # gem 'debugger', group: [:development, :test]
 
+gem 'fakeweb', '~> 1.3.0'
+
+
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.2'
   gem 'guard-rspec', '~> 4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
     factory_girl_rails (4.4.1)
       factory_girl (~> 4.4.0)
       railties (>= 3.0.0)
+    fakeweb (1.3.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.3)
@@ -254,6 +255,7 @@ DEPENDENCIES
   capybara (~> 2.4.1)
   coffee-rails (~> 4.0.0)
   factory_girl_rails (~> 4.4.1)
+  fakeweb (~> 1.3.0)
   guard-rspec (~> 4.3.1)
   jbuilder (~> 2.0)
   jquery-rails

--- a/spec/unit/lib/send_sms_spec.rb
+++ b/spec/unit/lib/send_sms_spec.rb
@@ -3,12 +3,41 @@ require "net/http"
 
 RSpec.describe SendSMS do
   describe "#send_sms" do
+
+    sms_info = {
+      from: "01054450754",
+      to: "01054450754",
+      user: "USERID",
+      password: "PASSWORD",
+      text: "TEST"
+    }
+
     it "should send SMS" do
       sms_sender = SendSMS.new
 
-      result = sms_sender.send_sms("01054450754", "01054450754", "test");
+      request_url = sms_sender.generate_request_url(sms_info)
+      body = "RESULT-CODE=00\n"
 
-      expect(result["result_code"]).to eq("200")
+      FakeWeb.register_uri(:get, request_url, :body => body)
+
+      result = sms_sender.send_sms(sms_info)
+
+      expect(result).to eq(true)
+    end
+
+    it "should fail to send SMS" do
+      sms_sender = SendSMS.new
+
+      request_url = sms_sender.generate_request_url(sms_info)
+      body = "RESULT-CODE=20\n"
+
+      FakeWeb.register_uri(:get, request_url, :body => body)
+
+      sms_sender = SendSMS.new
+
+      result = sms_sender.send_sms(sms_info)
+
+      expect(result).to eq(false)
     end
   end
 end


### PR DESCRIPTION
#233

문자를 발송하는 법은 rspec code를 참조해주세요.
인자값은

``` ruby
    sms_info = {
      from: "01054450754", #보내는 사람
      to: "01054450754", #받는 사람
      user: "USERID", #donutworks
      password: "PASSWORD", #donutwork1!
      text: "TEST" #SMS내용
    }
```

입니다. 
