### PR TITLE
no acceptance test w/ guard

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -9,7 +9,7 @@
 #                          installed the spring binstubs per the docs)
 #  * zeus: 'zeus rspec' (requires the server to be started separetly)
 #  * 'just' rspec: 'rspec'
-guard :rspec, cmd: 'bundle exec rspec' do
+guard :rspec, cmd: %q(bundle exec rspec --pattern "spec/unit/**/*_spec.rb") do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/unit/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }
@@ -27,7 +27,7 @@ guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^app/views/(.+)/.*\.(erb|haml|slim)$})     { |m| "spec/features/#{m[1]}_spec.rb" }
 
   # Turnip features and steps
-  watch(%r{^spec/acceptance/(.+)\.feature$})
-  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
+  # watch(%r{^spec/acceptance/(.+)\.feature$})
+  # watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
 end
 

--- a/spec/acceptance/root_page_spec.rb
+++ b/spec/acceptance/root_page_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "root page", type: :feature do
       click_button "전화번호로 로그인"
 
       expect(current_path).to eq(club_path(@user.club))
-      expect(page).to have_content("@ #{@user.club.name}")
+      expect(page).to have_content("안녕하세요 #{@user.username} 님!")
     end
 
     it "should show me clubs I joined" do
@@ -39,7 +39,7 @@ RSpec.describe "root page", type: :feature do
       click_button "전화번호로 로그인"
 
       click_button @user.club.name
-      expect(page).to have_content("@ #{@user.club.name}")
+      expect(page).to have_content("안녕하세요 #{@user.username} 님!")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,5 +71,5 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  # Capybara.default_driver = :selenium
+  Capybara.default_driver = ENV.fetch('CAPYBARA_DRIVER', :rack_test).to_sym
 end


### PR DESCRIPTION
#398

guard 에서는 all test를 돌려도 acceptance testing을 하지 않습니다.
여기에 #393 의 피드백도 반영했습니다.

``` ruby
CAPYBARA_DRIVER=selenium bundle exec rspec spec/acceptance
```

로 selenium으로 acceptance testing을 하실 수 있습니다.

테스트가 통과하지 않는 부분은 이상하네요 음.. 좀 더 살펴보아야 하겠습니다.
